### PR TITLE
Change heights to geopotential, clarify plots, fixes

### DIFF
--- a/GUI/src/plots.py
+++ b/GUI/src/plots.py
@@ -415,13 +415,19 @@ class Plots(object):
             ax.plot(x_max/2+n_refractivity_plot, z_vect+z_relief_2, color='b', label=None)
             ax.plot(3*x_max/4+n_refractivity_plot, z_vect+z_relief_3, color='b', label=None)
         else:
-            x = np.arange(0, x_max*1000, x_step) # x_max in kilometers
-            z = np.arange(0, z_max, z_step)
-            print(f"M shape : {n_refractivity.shape} ; N_x={n_x} N_z={n_z}")
+            # Since we plot a colormesh, x and z have to be 1 greater than n_refractivity
+            x = np.linspace(0, x_max, n_x+1) # plot is in km so x has to be in km
+            z = np.linspace(0, z_max, n_z+1)
+            # print(f"M shape : {n_refractivity.shape} ; N_x={n_x} N_z={n_z} ; #x={len(x)}, #z={len(z)}")
             if n_refractivity.shape == (n_x, n_z):
-                # transpose to obtain the correct dimension
-                plot = ax.pcolormesh(x, z, n_refractivity.T[:n_z,:n_x])
-                self.environment_colorbar = self.figure_environment.colorbar(plot, ax=ax, label="m gradient [m⁻¹]")
+                # transpose to obtain the correct dimension, convert m⁻¹ to km⁻¹
+                C = n_refractivity.T*1000
+                # Center color scale on 0
+                vmin = -np.max(np.abs(C))
+                vmax = np.max(np.abs(C))
+                # Plot colormesh with a diverging cmap
+                plot = ax.pcolormesh(x, z, C, vmin=vmin, vmax=vmax, cmap='PuOr_r')
+                self.environment_colorbar = self.figure_environment.colorbar(plot, ax=ax, label="m gradient [km⁻¹]")
         ax.legend()
 
         # plot atmosphere on relief

--- a/propagation/src/atmosphere/geopotential.py
+++ b/propagation/src/atmosphere/geopotential.py
@@ -1,0 +1,118 @@
+# This file is part of SSW-2D.
+# SSW-2D is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# SSW-2D is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Foobar. If not, see
+# <https://www.gnu.org/licenses/>.
+
+##
+# @author storca
+# @brief Regrid datasets from isobaric levels into geopotential height levels
+# @warning
+##
+
+import numpy as np
+from scipy.interpolate import CubicSpline
+import xarray as xr
+
+def regrid_dataset(ds: xr.Dataset, N_z, z_max) -> xr.Dataset:
+    """
+    Original dataset contains data in terms of isobaric surfaces.
+    This function re-grids the dataset in terms of geopotential height.
+
+    ds : xarray dataset
+    N_z : vertical sampling
+    z_max : maximum altitude (meters)
+
+    returns : the re-gridded dataset
+    """
+    # Dirty, but too many variables to pass to other functions
+    global d, P, time, h, Z
+
+    # Old coordinates
+    d = ds.d.data
+    P = ds.isobaricInhPa.data
+    time = ds.time.data
+
+    # New coordinate
+    h = np.linspace(0, z_max, N_z)
+
+    # Variables
+    r = ds.r.data
+    t = ds.t.data
+    z = ds.z.data
+
+    # Geopotential atlitudes
+    Z = ds.z.data/9.81
+
+    # New variables
+    new_shape = (len(time), N_z, len(d))
+    new_P = np.zeros(new_shape, dtype=float)
+    new_r = np.zeros(new_shape, dtype=float)
+    new_t = np.zeros(new_shape, dtype=float)
+    new_z = np.zeros(new_shape, dtype=float)
+
+    # Call regriding functions
+    regrid_P(new_P)
+    regrid_data(r, new_r)
+    regrid_data(t, new_t)
+    regrid_data(z, new_z)
+
+    # Instanciate the new dataset
+    new_ds = xr.Dataset(
+        data_vars=dict(
+            r=(['time', 'heights', 'd'], new_r),
+            t=(['time', 'heights', 'd'], new_t),
+            z=(['time', 'heights', 'd'], new_z),
+            isobaricInhPa=(['time', 'heights', 'd'], new_P),
+        ),
+        coords=dict(
+            time=time,
+            heights=h,
+            d=d
+        ),
+        attrs=ds.attrs
+    )
+    # Add metadata
+    new_ds["heights"] = new_ds.heights.assign_attrs({"long_name": "Geopotential height", "units": "m"})
+    new_ds["d"] = new_ds.d.assign_attrs(ds.d.attrs)
+    new_ds["r"] = new_ds.r.assign_attrs(ds.r.attrs)
+    new_ds["t"] = new_ds.t.assign_attrs(ds.t.attrs)
+    new_ds["z"] = new_ds.z.assign_attrs(ds.z.attrs)
+    new_ds["isobaricInhPa"] = new_ds.isobaricInhPa.assign_attrs(ds.isobaricInhPa.attrs)
+    return new_ds
+
+def regrid_P(new_P, scipy_interp_func=CubicSpline):
+    """
+    Regrid pressure data
+    """
+    for time_i in range(len(time)):
+        for d_i in range(len(d)):
+            # Local heights corresponding to each pressure level
+            z_local = Z[time_i,:,d_i]
+            # Coordinates of the pressure in terms of geopotential height
+            points = z_local
+            # Values of pressure at each height
+            values = P
+            P_func = np.vectorize(scipy_interp_func(points, values))
+
+            new_P[time_i, :, d_i] = P_func(h)
+
+def regrid_data(data, new_data, scipy_interp_func=CubicSpline):
+    """
+    Regrid dataset variable
+    """
+    for time_i in range(len(time)):
+        for d_i in range(len(d)):
+            # Local heights corresponding to each pressure level
+            z_local = Z[time_i,:,d_i]
+            # Coordinates of the data in terms of geopotential height
+            points = z_local
+            # Values of the given data
+            values = data[time_i,:,d_i]
+            D_func = np.vectorize(scipy_interp_func(points, values))
+
+            new_data[time_i, :, d_i] = D_func(h)

--- a/propagation/src/atmosphere/real_atmosphere.py
+++ b/propagation/src/atmosphere/real_atmosphere.py
@@ -23,6 +23,7 @@ from os.path import basename
 
 from src.classes_and_files.classes import Cache
 import src.classes_and_files.geodesic as geo
+import src.atmosphere.geopotential as geopot
 import src.atmosphere.cds as cds
 
 def normalize(ds: xr.Dataset) -> xr.Dataset:
@@ -52,18 +53,18 @@ def normalize(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def load(path: str, P: Tuple[float], Q: Tuple[float], N: int) -> xr.Dataset:
+def load(path: str, P: Tuple[float], Q: Tuple[float], N_x: int, N_z:int, z_max=3000.0) -> xr.Dataset:
     """
     Loads a given dataset, interpolates it on a line of N values between points P and Q and returns a smaller dataset.
 
-    path : path to a grib/netcdf dataset
-    P : latitude, longitude tuple of the first point
-    Q : latitude, longitude tuple of the second point
-    N : number of points to interpolate
+    P : latitude, longitude of the first point
+    Q : latitude, longitude of the second point
+    N_x : number of logitudinal points to interpolate
+    N_z : number of vertical points to interpolate
     ds : xarray dataset
     """
     # Check for cached datasets
-    cache_string = f"atmosphere,{P},{Q},{N},{basename(path)}"
+    cache_string = f"atmosphere,{P},{Q},{N_x},{N_z},{z_max},{basename(path)}"
     c = Cache(cache_string)
     ds = None
     if c.has():
@@ -76,9 +77,9 @@ def load(path: str, P: Tuple[float], Q: Tuple[float], N: int) -> xr.Dataset:
 
         print("[*] Interpolating positions...")
         # (P, Q) line (lat, lon) coordinates
-        lc = geo.geodesic_line_coords(P, Q, N)
+        lc = geo.geodesic_line_coords(P, Q, N_x)
         # (P, Q) line; azi : angle from P, ld = distances from P
-        azi, ld = geo.geodesic_line_distance(P, Q, N)
+        azi, ld = geo.geodesic_line_distance(P, Q, N_x)
 
         # Warning : brain juice below
         # Interpolate on the (P,Q) segment, using (lat, lon) couples by creating a new coordinate d which is the distance from P on the axis (P,Q)
@@ -89,8 +90,11 @@ def load(path: str, P: Tuple[float], Q: Tuple[float], N: int) -> xr.Dataset:
         # Add the distances array to the new coordinate
         ds = ds.assign_coords(dict(d=ld))
 
-        # Add metadata
         ds["d"] = ds.d.assign_attrs({"long_name": "Distance from P", "units": "m"})
+
+        # Regrid dataset, replace isobaric surfaces with heights
+        print("[*] Regriding dataset... ")
+        ds = geopot.regrid_dataset(ds, N_z, z_max)
 
         # Cache dataset
         c.store(ds)
@@ -146,7 +150,9 @@ def add_M(ds: xr.Dataset) -> xr.Dataset:
     def M(ds:xr.Dataset):
         return ds.heights/Re * 1e6 + ds.N
     ds = ds.assign(M=M)
+    ds = ds.assign(m = lambda ds: ds.n + ds.heights/Re)
     ds["M"] = ds.M.assign_attrs({"long_name": "Corefractivity index"})
+    ds["m"] = ds.m.assign_attrs({"long_name": "Corefraction index"})
     return ds
 
 def add_grad_m(ds: xr.Dataset) -> xr.Dataset:
@@ -247,20 +253,15 @@ def get_corefractive_index(config) -> np.ndarray:
     # Create time string used to select data
     time = c.atmosphere_datetime.strftime("%Y-%m-%dT%H:00:00.%f")
     # Load initial atmosphere dataset
-    a = load(path, c.P, c.Q, c.N_x)
+    a = load(path, c.P, c.Q, c.N_x, c.N_z, hmax)
     # Normalize vars and coords names
     a = normalize(a)
     # Compute the refraction index
     a = add_n(a)
-    a = add_heights(a, hmax)
     a = add_M(a)
-    # Add m
-    a = a.assign(m = lambda ds: ds.n + ds.heights/6.371e6)
     # Compute the gradient of the refraction index
     a = add_grad_n(a)
     a = add_grad_m(a)
-    # Interpolate all the dataset in between pressure levels, and convert pressure levels to meters
-    a = interpolate_vertical(a, c.N_z, hmax)
     # Save the gradient into a file to display it in the UI
     np.save('./inputs/refractivity_gradient.npy', a.grad_m.sel(time=time).to_numpy().T) # save to show it in the UI later
     # transpose the array, shape of (N_x, N_z) instead of (N_z, N_x)

--- a/propagation/src/classes_and_files/read_files.py
+++ b/propagation/src/classes_and_files/read_files.py
@@ -153,7 +153,7 @@ def read_source(config, file_source_config, file_e_init):
             # geometry must match with the source generation
             elif row[0] == 'frequency':
                 freq = float(row[1]) * 1e6  # freq in MHz
-                if freq != config.freq:
+                if freq - config.freq > 2*2.22e-16:
                     raise ValueError(['frequency ', freq, ' MHz value does not match with source generation',
                                     config.freq, ' MHz'])
             # x_s is the source position in the x direction (must be <0)

--- a/terrain/src/relief.py
+++ b/terrain/src/relief.py
@@ -184,7 +184,6 @@ def get_ign_height_profile(P: Tuple[float], Q: Tuple[float], N: int) -> xr.Datas
     if response.status_code == 200:
         # Convert JSON response to dict()
         d = response.json()
-        print(d)
         # Initialize data holders
         h = np.zeros(N, dtype=float)
         heights = []


### PR DESCRIPTION
The following improvements were made :
- Heights are no longer approximated by a barometric formula. Instead, geopotential heights are computed using the geopotential given in the datasets.
- The gradient of the refractive index is displayed with a 0-centered and divergent colormap for easier interpretation

This PR contains the following fixes :
- In ```propagation/src/classes_and_files/read_files.py```, frequency parameter was compared to another float using ```!=```. Float comparison has to be made relative to the machine epsilon. This sometimes lead to errors.
- Removed verbosity in ```terrain/src/relief.py```